### PR TITLE
fix parse_date TypeError exception

### DIFF
--- a/sdk/lib/ovirtsdk4/reader.py
+++ b/sdk/lib/ovirtsdk4/reader.py
@@ -17,6 +17,7 @@
 #
 
 import datetime
+import time
 import io
 import re
 import six
@@ -214,7 +215,10 @@ class Reader(object):
         if TZ_USEC_RE.search(text):
             format += '.%f'
         try:
-            date = datetime.datetime.strptime(text, format)
+            try:
+                date = datetime.datetime.strptime(text, format)
+            except TypeError:
+                date = datetime.datetime.fromtimestamp(time.mktime(time.strptime(text, format)))
         except ValueError:
             raise ValueError(
                 'The text \'%s\' isn\'t a valid date value' % text


### PR DESCRIPTION
Hi,

I'm getting the following exception on strptime:

2132e0b5afe7-fd (150): python-fd.c:1183-78 python-fd: Traceback (most recent call last):
  File "/usr/lib/bareos/plugins/BareosFdWrapper.py", line 38, in handle_plugin_event
    return bareos_fd_plugin_object.handle_plugin_event(context, event)
  File "/usr/lib/bareos/plugins/BareosFdPluginOvirt.py", line 161, in handle_plugin_event
    return self.start_backup_job(context)
  File "/usr/lib/bareos/plugins/BareosFdPluginOvirt.py", line 57, in start_backup_job
    if not self.ovirt.connect_api(context, self.options):
  File "/usr/lib/bareos/plugins/BareosFdPluginOvirt.py", line 254, in connect_api
    res = self.vms_service.list(search="name=issabel", all_content=True)
  File "/usr/local/lib/python2.7/dist-packages/ovirtsdk4/services.py", line 33387, in list
    return self._internal_get(headers, query, wait)
  File "/usr/local/lib/python2.7/dist-packages/ovirtsdk4/service.py", line 211, in _internal_get
    return future.wait() if wait else future
  File "/usr/local/lib/python2.7/dist-packages/ovirtsdk4/service.py", line 55, in wait
    return self._code(response)
  File "/usr/local/lib/python2.7/dist-packages/ovirtsdk4/service.py", line 206, in callback
    return self._internal_read_body(response)
  File "/usr/local/lib/python2.7/dist-packages/ovirtsdk4/service.py", line 319, in _internal_read_body
    return reader.Reader.read(response.body)
  File "/usr/local/lib/python2.7/dist-packages/ovirtsdk4/reader.py", line 331, in read
    return reader(cursor)
  File "/usr/local/lib/python2.7/dist-packages/ovirtsdk4/readers.py", line 17501, in read_many
    objs.append(VmReader.read_one(reader))
  File "/usr/local/lib/python2.7/dist-packages/ovirtsdk4/readers.py", line 17329, in read_one
    obj.creation_time = Reader.read_date(reader)
  File "/usr/local/lib/python2.7/dist-packages/ovirtsdk4/reader.py", line 235, in read_date
    return Reader.parse_date(reader.read_element())
  File "/usr/local/lib/python2.7/dist-packages/ovirtsdk4/reader.py", line 217, in parse_date
    date = datetime.datetime.strptime(text, format)
TypeError: attribute of type 'NoneType' is not callable

There is a issue for python module: https://bugs.python.org/issue27400

So, i make this commit to workaround this issue.

Regards,
Carlos Rodrigues
