### PR TITLE
changed hrefs for 4.2, 4.3 documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,12 +80,12 @@
                 <span class="name">4.4</span>
             </a>
         </p>        <p>
-            <a href="4.3">
+            <a href="4.3/4.3.2">
                 <span class="name">4.3</span>
             </a>
         </p>
         <p>
-            <a href="4.2">
+            <a href="4.2/4.2.9">
                 <span class="name">4.2</span>
             </a>
         </p>


### PR DESCRIPTION
Links to 4.2, 4.3 documentations are altered to include sub-directories to latest 4.2.x, 4.3.x versions.

Signed-off-by: Ori_Liel <oliel@redhat.com>