### PR TITLE
Optimize build workflows:

### DIFF
--- a/.github/workflows/build-on-merge.yml
+++ b/.github/workflows/build-on-merge.yml
@@ -1,5 +1,4 @@
-
-name: ovirt-engine-sdk GitHub Actions
+name: build-on-merge
 
 on:
   push:
@@ -31,10 +30,7 @@ jobs:
         run: sudo apt-get update
 
       - name: Install package dependencies
-        run: sudo apt-get install mmv libssl-dev libcurl4-openssl-dev python-dev python3-pip
-
-      - name: Install python dependencies
-        run: pip3 install flake8==3.7.7
+        run: sudo apt-get install mmv libssl-dev libcurl4-openssl-dev python-dev python3-pip flake8
 
       - name: Set git defaults
         run: |

--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -1,11 +1,5 @@
-
-name: ovirt-engine-sdk GitHub Actions
-
-on:
-  pull_request:
-    branches:
-      - master
-  workflow_dispatch:
+name: build-on-pr
+on: [ pull_request, workflow_dispatch ]
 
 env:
   LD_LIBRARY_PATH: /usr/local/opt/curl/lib:$LD_LIBRARY_PATH
@@ -25,14 +19,8 @@ jobs:
           distribution: 'adopt'
           cache: 'maven'
 
-      - name: Update packages
-        run: sudo apt-get update
-
       - name: Install package dependencies
-        run: sudo apt-get install mmv libssl-dev libcurl4-openssl-dev python-dev python3-pip
-
-      - name: Install python dependencies
-        run: pip3 install flake8==3.7.7
+        run: sudo apt-get install mmv libssl-dev libcurl4-openssl-dev python3-dev python3-pip flake8
 
       - name: Run maven build
         run: mvn package -B


### PR DESCRIPTION
1. Sets relevant workflow names
2. Use apt to install flake8 instead of pip
3. Don't unnecessarily update packages on startup

Signed-off-by: Martin Perina <mperina@redhat.com>
