### PR TITLE
bump model, metamodel versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,8 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Version of the metamodel and model used to generate the SDK: -->
-    <metamodel.version>1.3.4</metamodel.version>
-    <model.version>4.5.0</model.version>
+    <metamodel.version>1.3.7</metamodel.version>
+    <model.version>4.5.7</model.version>
 
     <!-- The command used to start Python: -->
     <python.command>python3</python.command>


### PR DESCRIPTION
Model version 4.5.7
Metamodel version 1.3.7

Signed-off-by: Ori Liel <oliel@redhat.com>