### PR TITLE
generator: replace link in follow parameter

### DIFF
--- a/generator/src/main/java/org/ovirt/sdk/python/PythonBuffer.java
+++ b/generator/src/main/java/org/ovirt/sdk/python/PythonBuffer.java
@@ -171,6 +171,11 @@ public class PythonBuffer {
             prepLine = replaceTypeAttributeXrefs(prepLine);
             prepLine = replaceTypeXrefs(prepLine);
             addRawLine(prepLine);
+        } else if (line.contains("<<documents/003_common_concepts/follow, here>>")){
+            String prepLine = line.strip();
+            prepLine = prepLine.replace("<<documents/003_common_concepts/follow, here>>", 
+            "[here](https://ovirt.github.io/ovirt-engine-api-model/master/#documents/003_common_concepts/follow)");
+            addRawLine(prepLine);
         } else {
             addRawLine(line);
         }


### PR DESCRIPTION
## Changes introduced with this PR

 * in the follow parameter there is a link to the api documentation, generate a working link to this.

Before:
follow: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part of the current request. See <> for details.

Updated:
follow: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part of the current request. See [here](https://github.com/oVirt/ovirt-engine-api-model/blob/master/src/main/java/003-CommonConcepts.adoc#following-links) for details.